### PR TITLE
MemoryDataLayer optional fields for DataFrames

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -794,6 +794,10 @@ message MemoryDataParameter {
   optional bool share_in_parallel = 5 [default = true];
   // Specify location of source
   optional string source = 6;
+  // SQL statements to select columns from dataframes
+  repeated string dataframe_column_select = 7;
+  // Is image data encoded in dataframes?
+  optional bool image_encoded = 8 [default = false];
 }
 
 message MVNParameter {


### PR DESCRIPTION
We introduce 2 new fields into MemoryDataLayer: dataframe_column_select and image_encoded.

Each dataframe_column_select should be a SQL expression for producing a named column. 
See Spark documentation for details. 

image_encoded is used to indicated images are encoded.
